### PR TITLE
Fix typo in package name in .sty file

### DIFF
--- a/NEU_COS_thesis_style.sty
+++ b/NEU_COS_thesis_style.sty
@@ -2,7 +2,7 @@
 % Adapted from University of Pennsylvania Ph.D. Dissertation LaTeX Template and Penn Biostat LaTeX Template, which was modified from the Dissertation Template for Wharton PhD Candidates in LaTeX.
 
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{NEU_thesis_style_COS}[2022/04/28 Thesis Style]
+\ProvidesPackage{NEU_COS_thesis_style}[2022/04/28 Thesis Style]
 
 \RequirePackage[left=1in,
                 right=1in,


### PR DESCRIPTION
This avoid the following warning:

    LaTeX Warning: You have requested package `NEU_COS_thesis_style',
               but the package provides `NEU_thesis_style_COS'.